### PR TITLE
Prepare an environment to develop on MacOS by PyCharm

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ eradicate-aggressive = True
 ban-relative-imports = True
 exclude =
   .tox
+  node_modules
 # We're fine to have class attributes with the name `list`.
 # Document dunder methods is also redundant.
 # Line breaks before binary operator is also fine.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 htmlcov/
 node_modules/
 package-lock.json
+/src/editors.egg-info/
+.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,12 @@
 *.pyc
 *~
 .coverage
+.idea
 .mypy_cache/
 .tox/
+/src/editors.egg-info/
 __pycache__/
 dist/
 htmlcov/
 node_modules/
 package-lock.json
-/src/editors.egg-info/
-.idea
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: ""
     hooks:
       - id: reorder-python-imports
-        args: [--application-directories=.:src:tests/helpers]
+        args: ["--application-directories=.:src:tests/helpers"]
         # override until resolved:
         # https://github.com/asottile/reorder_python_imports/issues/103
         files: \.pyi?$

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ stories-upgrade $(git ls-files '*.py')
 +        ctx.category = category
 +        return Success()
 ```
+
+For MacOS X contributors only:
+
+1. You need to install gnu-sed
+
+   ```bash
+   brew install gnu-sed
+   ```
+
+   then you have to **add\modify to your PATH like this 'PATH="/usr/local/opt/gnu-sed/libexec/gnubin:\$PATH"' from your ~/.bashrc or ~/.zshrc**
+
+2. You need to install valve linter
+
+   ```bash
+   brew install vale
+   ```

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
   pre-commit autoupdate
   pre-commit run {posargs:--all-files}
-commands_post = sed -i '' 's/rev: .*$/rev: ""/g' .pre-commit-config.yaml
+commands_post = sed -i 's/rev: .*$/rev: ""/g' .pre-commit-config.yaml
 whitelist_externals = sed
 
 [testenv:stories-upgrade]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
   pre-commit autoupdate
   pre-commit run {posargs:--all-files}
-commands_post = sed -i 's/rev: .*$/rev: ""/g' .pre-commit-config.yaml
+commands_post = sed -i '' 's/rev: .*$/rev: ""/g' .pre-commit-config.yaml
 whitelist_externals = sed
 
 [testenv:stories-upgrade]


### PR DESCRIPTION
On MacOS we need:
1. escape colon in yaml by quotes 
2. use `sed -i ''`  instead `sed -i`